### PR TITLE
Show total played time in days when >= 24 hours

### DIFF
--- a/AccountPlayed.lua
+++ b/AccountPlayed.lua
@@ -46,6 +46,11 @@ local function FormatTimeSmart(seconds, useYears)
     else
         local h = math.floor(hours)
         local m = math.floor((seconds % 3600) / 60)
+        if h >= 24 then
+            local days = math.floor(h / 24)
+            local remH = h % 24
+            return string.format("%dd %dh %dm", days, remH, m)
+        end
         return string.format("%dh %dm", h, m)
     end
 end


### PR DESCRIPTION
### Problem

The TOTAL line at the bottom of the popup displayed raw hours (e.g., "TOTAL: 5785h 52m"), which is hard to read at a glance for large values.

### Solution

Added a `>= 24h` check in `FormatTimeSmart` to display days/hours/minutes format instead.

- **Before**: `TOTAL: 5785h 52m`
- **After**: `TOTAL: 241d 1h 52m`

Values under 24 hours still display as `#h #m`. Per-class rows (which use a separate `FormatTime` function) are unaffected.