### PR TITLE
Widen class name column to prevent truncation

### DIFF
--- a/AccountPlayed.lua
+++ b/AccountPlayed.lua
@@ -116,7 +116,7 @@ local function CreateRow(parent, width, height)
     -- Class name
     row.classText = row:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     row.classText:SetPoint("LEFT", 0, 0)
-    row.classText:SetWidth(100)
+    row.classText:SetWidth(120)
     row.classText:SetJustifyH("LEFT")
 
     -- Status bar (dynamic width via anchors)


### PR DESCRIPTION
### Problem

The class name column was hardcoded to 100px, causing "DEATHKNIGHT" (and "DEMONHUNTER") to be cut off regardless of window size.

### Solution

Increased `row.classText:SetWidth()` from 100 to 120 pixels. Status bars adjust automatically since they're anchored relative to the class text -- no other layout changes needed.